### PR TITLE
feat: MBTI 모델 출력 정규화 및 ISBN 기반 book_id 조회 로직 수정

### DIFF
--- a/python/src/model/mbtimlp.py
+++ b/python/src/model/mbtimlp.py
@@ -18,4 +18,6 @@ class MBTIModel(nn.Module):
     def forward(self, input_ids, attention_mask):
         outputs = self.bert(input_ids=input_ids, attention_mask=attention_mask)
         cls_embedding = outputs.last_hidden_state[:, 0, :]  # [CLS] 토큰
-        return self.classifier(cls_embedding)
+        raw_output = self.classifier(cls_embedding)
+        normalized_output = (raw_output + 1) / 2 * 100
+        return normalized_output

--- a/python/src/recommender/book_recommender_local.py
+++ b/python/src/recommender/book_recommender_local.py
@@ -95,14 +95,15 @@ def get_book_id_by_isbn(isbn):
     )
     try:
         with connection.cursor() as cursor:
-            sql = "SELECT book_id, name FROM book"
-            cursor.execute(sql)
-            results = cursor.fetchall()
-            for row in results:
-                return row['book_id']
+            sql = "SELECT book_id FROM book WHERE isbn = %s"
+            cursor.execute(sql, (isbn,))
+            result = cursor.fetchone()
+            if result:
+                return result['book_id']
+            else:
+                return None
     finally:
         connection.close()
-        return None
 
 # ===== 경로 및 파일 설정 ===== #
 dest = os.path.join('../../data/cache')
@@ -203,6 +204,7 @@ else:
 
     for i, row in df_para.iterrows():
         isbn = row["isbn"]
+        book_id = get_book_id_by_isbn(isbn)
 
         if isbn is None:
             print(f"[WARN] book_id를 찾을 수 없습니다: '{isbn}'")
@@ -212,11 +214,11 @@ else:
         mbti_score = {k: float(v * 100) for k, v in zip(CACHE_KEYS, mbti_tensor)}
 
         raw_dataset.append({
-            "book_id": row["isbn"],
+            "book_id": book_id,
             "title": row["title"],
             "paragraph": row["paragraph"],
             "mbti_score": mbti_score,
-            "isbns": isbn
+            "isbn": isbn
         })
 
     with open(CACHE_EMB_PATH, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
### 주요 변경 사항
- `MBTIModel` 클래스: Tanh() 출력값을 (output + 1) / 2 * 100 으로 정규화하여 0~100 스케일의 MBTI 점수 반환
- DB 접근 함수 `get_book_id_by_isbn(isbn)` 수정: 전체 조회 방식에서 `isbn`을 기준으로 특정 book_id 조회하도록 개선

### 목적
- 모델 출력값을 실질적인 점수형태로 변환하여 후처리 없이 추천 시스템에서 바로 사용 가능하게 개선
- 잘못된 book_id 매핑 문제를 해결하고 정확한 도서 정보 연결 가능하도록 DB 조회 로직 개선

### 확인 사항
- 정규화 로직은 모델 `forward()` 내부에서 자동 처리
- `isbn` 값이 없거나 조회 결과가 없을 경우 `None` 반환 처리 포함